### PR TITLE
feat(v1.6.0): Phase 1 — DAO layer, structured events, observability

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ltm",
   "description": "Long-Term Memory system for Claude Code \u2014 semantic search, context injection, session learning",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "author": {
     "name": "RohiRIK"
   },

--- a/commands/health.md
+++ b/commands/health.md
@@ -31,6 +31,47 @@ If the server is NOT running, show: `(graph server offline — start with /ltm:a
 
 ---
 
+## Activity (last 24 h)
+
+Aggregate structured events from `~/.claude/logs/hooks.log`:
+
+```bash
+bun --eval "
+import { readFileSync, existsSync } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+const LOG = join(homedir(), '.claude', 'logs', 'hooks.log');
+if (!existsSync(LOG)) { console.log('No hooks.log yet — hooks have not fired.'); process.exit(0); }
+const cutoff = Date.now() - 24 * 60 * 60 * 1000;
+const counts = {};
+readFileSync(LOG, 'utf-8').trim().split('\n').forEach(line => {
+  try {
+    const e = JSON.parse(line);
+    if (e.level !== 'event' || !e.event) return;
+    if (new Date(e.ts).getTime() < cutoff) return;
+    counts[e.event] = (counts[e.event] ?? 0) + 1;
+  } catch {}
+});
+const LABELS = {
+  'session.start':     'Sessions started',
+  'session.evaluated': 'Sessions evaluated',
+  'context.updated':   'Context updates',
+  'compact.pre':       'Compactions',
+  'recall.hit':        'Recall hits',
+  'learn.write':       'Memories learned',
+  'wizard.complete':   'Wizard completions',
+};
+console.log('Activity (last 24 h)');
+console.log('────────────────────');
+const keys = Object.keys(LABELS);
+const any = keys.some(k => counts[k]);
+if (!any) { console.log('  No hook events yet.'); }
+else { keys.forEach(k => { if (counts[k]) console.log('  ' + (LABELS[k] ?? k).padEnd(22) + counts[k]); }); }
+"
+```
+
+---
+
 ## Memory Decay Summary
 
 Always run, regardless of graph server status:

--- a/hooks/lib/eventNames.ts
+++ b/hooks/lib/eventNames.ts
@@ -1,0 +1,12 @@
+/** Canonical event names written to hooks.log — consumed by /ltm:health for activity aggregation. */
+export const EVENTS = {
+  SESSION_START:      "session.start",
+  SESSION_EVALUATED:  "session.evaluated",
+  CONTEXT_UPDATED:    "context.updated",
+  COMPACT_PRE:        "compact.pre",
+  RECALL_HIT:         "recall.hit",
+  LEARN_WRITE:        "learn.write",
+  WIZARD_COMPLETE:    "wizard.complete",
+} as const;
+
+export type EventName = typeof EVENTS[keyof typeof EVENTS];

--- a/hooks/lib/hookLogger.ts
+++ b/hooks/lib/hookLogger.ts
@@ -28,9 +28,10 @@ export interface LogEntry {
 const LOG_PATH = join(homedir(), ".claude", "logs", "hooks.log");
 const MAX_BYTES = 500_000;   // 500 KB — rotate above this
 const KEEP_BYTES = 300_000;  // keep last 300 KB after rotation
+const ROTATE_INTERVAL_MS = 60_000; // check at most once per minute
 
-// Cache dir-creation so it only runs once per process
 let _dirEnsured = false;
+let _lastRotateCheckAt = 0;
 
 function ensureDir(): void {
   if (_dirEnsured) return;
@@ -39,9 +40,12 @@ function ensureDir(): void {
 }
 
 function rotate(): void {
+  const now = Date.now();
+  if (now - _lastRotateCheckAt < ROTATE_INTERVAL_MS) return;
+  _lastRotateCheckAt = now;
   try {
     let size: number;
-    try { size = statSync(LOG_PATH).size; } catch { return; } // file doesn't exist yet
+    try { size = statSync(LOG_PATH).size; } catch { return; }
     if (size <= MAX_BYTES) return;
     writeFileSync(LOG_PATH, readFileSync(LOG_PATH, "utf-8").slice(-KEEP_BYTES));
   } catch (_) {

--- a/hooks/lib/hookLogger.ts
+++ b/hooks/lib/hookLogger.ts
@@ -8,7 +8,7 @@ import { appendFileSync, readFileSync, mkdirSync, statSync, writeFileSync } from
 import { join, dirname } from "path";
 import { homedir } from "os";
 
-export type LogLevel = "info" | "warn" | "error";
+export type LogLevel = "info" | "warn" | "error" | "event";
 
 export interface LogEntry {
   ts: string;
@@ -17,6 +17,12 @@ export interface LogEntry {
   msg: string;
   detail?: string;
   durationMs?: number;
+  /** Structured event name — present when level === "event". Consumed by /ltm:health. */
+  event?: string;
+  /** Optional count for aggregation (e.g. memories recalled, items written). */
+  count?: number;
+  /** Project scope for the event. */
+  project?: string;
 }
 
 const LOG_PATH = join(homedir(), ".claude", "logs", "hooks.log");
@@ -67,6 +73,35 @@ export function logHook(
   } catch (fallbackErr) {
     // logger itself failed — never crash the hook
     console.error(`[hookLogger] Failed to write log: ${fallbackErr}`);
+  }
+}
+
+/**
+ * Emit a structured activity event to hooks.log.
+ * Events are aggregated by /ltm:health to show real activity counts.
+ */
+export function logEvent(
+  hook: string,
+  event: string,
+  opts?: { project?: string; count?: number; detail?: string; durationMs?: number },
+): void {
+  try {
+    ensureDir();
+    rotate();
+    const entry: LogEntry = {
+      ts: new Date().toISOString(),
+      hook,
+      level: "event",
+      msg: event,
+      event,
+      ...(opts?.project !== undefined && { project: opts.project }),
+      ...(opts?.count !== undefined && { count: opts.count }),
+      ...(opts?.detail !== undefined && { detail: opts.detail }),
+      ...(opts?.durationMs !== undefined && { durationMs: opts.durationMs }),
+    };
+    appendFileSync(LOG_PATH, JSON.stringify(entry) + "\n");
+  } catch {
+    // event logging failure is non-fatal
   }
 }
 

--- a/hooks/src/EvaluateSession.ts
+++ b/hooks/src/EvaluateSession.ts
@@ -219,10 +219,8 @@ async function main() {
 
     const projectName = resolveProject(input.cwd ?? "").name;
 
-    // Collect proposals instead of writing to DB
     const proposals: MemoryProposal[] = [];
 
-    // Error blocks → gotcha proposals (no DB write)
     for (const msg of errorBlocks.slice(0, 3)) {
       if (msg.trim().length > 20) {
         proposals.push({
@@ -234,14 +232,12 @@ async function main() {
       }
     }
 
-    // LLM extraction → proposals (no DB write)
     try {
       if ((readConfigSync() as Config).ltm?.evaluateSessionLlm) {
         const assistantText = extractAssistantText(messages);
         if (assistantText.length > 100) {
           extractProposals(assistantText, projectName, { source: "evaluate-session", sessionId })
             .then(({ proposals: llmProposals }) => {
-              // Merge LLM proposals and write the full set
               const merged = [...proposals, ...llmProposals];
               if (merged.length > 0) {
                 const sid = sessionId ?? `unknown-${Date.now()}`;
@@ -255,7 +251,6 @@ async function main() {
             })
             .catch((err: unknown) => {
               logHook("EvaluateSession", "warn", "LLM extraction failed", String(err));
-              // Still write error-block proposals if any
               if (proposals.length > 0) {
                 const sid = sessionId ?? `unknown-${Date.now()}`;
                 const proposalsPath = join(PROPOSALS_DIR, `${sid}.json`);

--- a/hooks/src/EvaluateSession.ts
+++ b/hooks/src/EvaluateSession.ts
@@ -3,7 +3,8 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync, readdirSync } from 
 import { join } from "path";
 import { homedir } from "os";
 import { resolveProject, PROJECTS_DIR, CLAUDE_DIR, getDbPath } from "../lib/resolveProject.js";
-import { logHook } from "../lib/hookLogger.js";
+import { logHook, logEvent } from "../lib/hookLogger.js";
+import { EVENTS } from "../lib/eventNames.js";
 import { safeRun } from "../lib/hookUtils.js";
 import { extractProposals } from "../lib/llmExtract.js";
 import { writeProposals, type MemoryProposal } from "../lib/proposalQueue.js";
@@ -287,6 +288,8 @@ async function main() {
     } catch (cfgErr) {
       logHook("EvaluateSession", "warn", "Failed to read config for LLM extraction", String(cfgErr));
     }
+
+    logEvent("EvaluateSession", EVENTS.SESSION_EVALUATED, { project: projectName, count: messageCount });
 
     // Update Summary (deduplicate by sessionId)
     if (!existsSync(SUMMARY_FILE)) {

--- a/hooks/src/PreCompact.ts
+++ b/hooks/src/PreCompact.ts
@@ -3,7 +3,8 @@ import { existsSync, mkdirSync, writeFileSync } from "fs";
 import { join } from "path";
 import { resolveProject, getDbPath } from "../lib/resolveProject.js";
 import { readStdin, parseHookInput, readFileSafe, budgetSection, safeRun } from "../lib/hookUtils.js";
-import { logHook } from "../lib/hookLogger.js";
+import { logHook, logEvent } from "../lib/hookLogger.js";
+import { EVENTS } from "../lib/eventNames.js";
 import { getItems, exportContextMarkdown } from "../../src/context.js";
 
 const DB_PATH = getDbPath();
@@ -59,6 +60,7 @@ async function main(): Promise<void> {
 
   writeFileSync(join(projectDir, "context-summary.md"), finalSummary);
   logHook("PreCompact", "info", `Saved context summary for "${name}" (${finalSummary.split("\n").length} lines)`);
+  logEvent("PreCompact", EVENTS.COMPACT_PRE, { project: name });
 }
 
 await safeRun("PreCompact", main);

--- a/hooks/src/SessionStart.ts
+++ b/hooks/src/SessionStart.ts
@@ -3,7 +3,8 @@ import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "fs
 import { join } from "path";
 import { resolveProject, registerPath, PROJECTS_DIR, CLAUDE_DIR, getDbPath } from "../lib/resolveProject.js";
 import { readStdin, parseHookInput, trimToLines, readFileSafe, safeRun } from "../lib/hookUtils.js";
-import { logHook } from "../lib/hookLogger.js";
+import { logHook, logEvent } from "../lib/hookLogger.js";
+import { EVENTS } from "../lib/eventNames.js";
 import { spawnSync } from "child_process";
 import { getContextMerge, getSimilarMemories, getContextMergeWithGraph, computeDecayScore } from "../../src/db.js";
 import { embedText } from "../../src/embeddings.js";
@@ -204,6 +205,7 @@ async function main(): Promise<void> {
 
   process.stdout.write(output);
   logHook("SessionStart", "info", `Injected context for "${name}" (${registeredPath ? "registry" : "slug fallback"})`);
+  logEvent("SessionStart", EVENTS.SESSION_START, { project: name });
 }
 
 safeRun("SessionStart", main).then(result => {

--- a/hooks/src/UpdateContext.ts
+++ b/hooks/src/UpdateContext.ts
@@ -4,8 +4,9 @@ import { homedir } from "os";
 import { join } from "path";
 import { resolveProject, PROJECTS_DIR, CLAUDE_DIR, getDbPath } from "../lib/resolveProject.js";
 import { readStdinPassthrough, parseHookInput, readFileSafe, appendLine, trimToLines, safeRun } from "../lib/hookUtils.js";
-import { logHook } from "../lib/hookLogger.js";
-import { addItem } from "../../src/context.js";
+import { logHook, logEvent } from "../lib/hookLogger.js";
+import { EVENTS } from "../lib/eventNames.js";
+import { appendProgress, addDecision, addGotcha } from "../../src/dao/index.js";
 
 const TOOL_NAMES = new Set(["Write", "Edit", "MultiEdit"]);
 const MAX_PROGRESS_LINES = 20;
@@ -109,13 +110,13 @@ async function main(): Promise<void> {
       if (prefixMatch) {
         const type = prefixMatch[1]!.toLowerCase() as "decision" | "gotcha";
         const strippedContent = sessionLine.slice(prefixMatch[0].length);
-        addItem(name, type, strippedContent, sessionTag ?? undefined);
-        // Phase 2: decisions/gotchas are auto-promoted to pending memories
-        // by the janitor's runPromote() — no direct promote() call needed.
+        if (type === "decision") addDecision(name, strippedContent);
+        else addGotcha(name, strippedContent);
       } else {
-        addItem(name, "progress", sessionLine, sessionTag ?? undefined);
+        appendProgress(name, sessionLine, sessionTag ?? undefined);
       }
       logHook("UpdateContext", "info", `context DB updated for ${name}`);
+      logEvent("UpdateContext", EVENTS.CONTEXT_UPDATED, { project: name });
       return;
     } catch (dbErr) {
       logHook("UpdateContext", "warn", "DB write failed, falling back to .md", String(dbErr));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ltm-plugin",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Long-Term Memory plugin for Claude Code",
   "type": "module",
   "scripts": {

--- a/src/__tests__/dao/contextItems.test.ts
+++ b/src/__tests__/dao/contextItems.test.ts
@@ -1,0 +1,145 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { Database } from "bun:sqlite";
+import { readFileSync, unlinkSync } from "fs";
+import { join } from "path";
+
+// Unique path per process+timestamp to avoid collisions when tests run in parallel
+const dbPath = `/tmp/test-ltm-dao-${process.pid}-${Date.now()}.db`;
+const schemaPath = join(import.meta.dir, "..", "..", "..", "src", "schema.sql");
+
+// Deferred — imported after the DB is injected
+let listByProject: typeof import("../../dao/contextItems.js").listByProject;
+let appendProgress: typeof import("../../dao/contextItems.js").appendProgress;
+let upsertGoal: typeof import("../../dao/contextItems.js").upsertGoal;
+let addDecision: typeof import("../../dao/contextItems.js").addDecision;
+let addGotcha: typeof import("../../dao/contextItems.js").addGotcha;
+let writeQueue: typeof import("../../lib/writeQueue.js").writeQueue;
+
+async function drain() {
+  await writeQueue.enqueue(() => {});
+}
+
+beforeAll(async () => {
+  // Create a fully-migrated test DB without touching the shared-db singleton env var.
+  // This avoids the process.env.LTM_DB_PATH race when test files run concurrently.
+  const { runPendingMigrations } = await import("../../migrations.js");
+  const { _setDbForTesting } = await import("../../shared-db.js");
+
+  const testDb = new Database(dbPath, { create: true });
+  testDb.exec("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON; PRAGMA busy_timeout=5000;");
+  testDb.exec(readFileSync(schemaPath, "utf-8"));
+  await runPendingMigrations(testDb);
+
+  // Inject the fresh DB so all DAO functions use it
+  _setDbForTesting(testDb);
+
+  const dao = await import("../../dao/contextItems.js");
+  const wq = await import("../../lib/writeQueue.js");
+  listByProject = dao.listByProject;
+  appendProgress = dao.appendProgress;
+  upsertGoal = dao.upsertGoal;
+  addDecision = dao.addDecision;
+  addGotcha = dao.addGotcha;
+  writeQueue = wq.writeQueue;
+}, 30_000);
+
+afterAll(() => {
+  try { unlinkSync(dbPath); } catch {}
+  try { unlinkSync(`${dbPath}-shm`); } catch {}
+  try { unlinkSync(`${dbPath}-wal`); } catch {}
+});
+
+const PROJECT = "dao-test-project";
+
+describe("listByProject", () => {
+  it("returns empty array for unknown project", () => {
+    const rows = listByProject("nonexistent-xyz-12345");
+    expect(rows).toEqual([]);
+  });
+
+  it("filters by type when given", async () => {
+    appendProgress(PROJECT, "progress entry A");
+    addDecision(PROJECT, "decision entry B");
+    await drain();
+    const progress = listByProject(PROJECT, "progress");
+    const decisions = listByProject(PROJECT, "decision");
+    expect(progress.every(r => r.type === "progress")).toBe(true);
+    expect(decisions.every(r => r.type === "decision")).toBe(true);
+  });
+});
+
+describe("appendProgress", () => {
+  const PROJ = "dao-progress-test";
+
+  it("inserts a progress row", async () => {
+    appendProgress(PROJ, "step one done");
+    await drain();
+    const rows = listByProject(PROJ, "progress");
+    expect(rows.length).toBeGreaterThanOrEqual(1);
+    expect(rows.some(r => r.content === "step one done")).toBe(true);
+  });
+
+  it("records session_id when provided", async () => {
+    appendProgress(PROJ, "with session", "sess-abc");
+    await drain();
+    const rows = listByProject(PROJ, "progress");
+    const row = rows.find(r => r.content === "with session");
+    expect(row?.session_id).toBe("sess-abc");
+  });
+
+  it("trims to 20 most recent rows", async () => {
+    const TRIM_PROJ = "dao-trim-test";
+    for (let i = 0; i < 22; i++) {
+      appendProgress(TRIM_PROJ, `entry-${i}`);
+    }
+    await drain();
+    const rows = listByProject(TRIM_PROJ, "progress");
+    expect(rows.length).toBeLessThanOrEqual(20);
+  });
+});
+
+describe("upsertGoal", () => {
+  const PROJ = "dao-goal-test";
+
+  it("inserts a goal", async () => {
+    upsertGoal(PROJ, "build the feature");
+    await drain();
+    const rows = listByProject(PROJ, "goal");
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.content).toBe("build the feature");
+  });
+
+  it("replaces the existing goal", async () => {
+    upsertGoal(PROJ, "new goal");
+    await drain();
+    const rows = listByProject(PROJ, "goal");
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.content).toBe("new goal");
+  });
+});
+
+describe("addDecision", () => {
+  const PROJ = "dao-decision-test";
+
+  it("inserts a permanent decision row", async () => {
+    addDecision(PROJ, "use bun not npm");
+    await drain();
+    const rows = listByProject(PROJ, "decision");
+    expect(rows.some(r => r.content === "use bun not npm")).toBe(true);
+    const row = rows.find(r => r.content === "use bun not npm");
+    expect(row?.permanent).toBe(1);
+  });
+});
+
+describe("addGotcha", () => {
+  const PROJ = "dao-gotcha-test";
+
+  it("inserts a permanent gotcha row", async () => {
+    addGotcha(PROJ, "embedding SELECT * is slow");
+    await drain();
+    const rows = listByProject(PROJ, "gotcha");
+    expect(rows.some(r => r.content === "embedding SELECT * is slow")).toBe(true);
+    const row = rows.find(r => r.content === "embedding SELECT * is slow");
+    expect(row?.permanent).toBe(1);
+  });
+});

--- a/src/__tests__/hooks/event-emission.test.ts
+++ b/src/__tests__/hooks/event-emission.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Verify that hook source files import and emit the expected structured events.
+ * This is a static analysis test — it checks source code, not runtime behaviour.
+ */
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const HOOKS_SRC = join(import.meta.dir, "..", "..", "..", "hooks", "src");
+
+function hookSrc(name: string): string {
+  return readFileSync(join(HOOKS_SRC, name), "utf-8");
+}
+
+describe("structured event emission", () => {
+  it("SessionStart imports logEvent and EVENTS", () => {
+    const src = hookSrc("SessionStart.ts");
+    expect(src).toContain("logEvent");
+    expect(src).toContain("EVENTS");
+    expect(src).toContain("eventNames.js");
+  });
+
+  it("SessionStart emits SESSION_START event", () => {
+    const src = hookSrc("SessionStart.ts");
+    expect(src).toContain("EVENTS.SESSION_START");
+  });
+
+  it("UpdateContext imports logEvent and EVENTS", () => {
+    const src = hookSrc("UpdateContext.ts");
+    expect(src).toContain("logEvent");
+    expect(src).toContain("EVENTS");
+    expect(src).toContain("eventNames.js");
+  });
+
+  it("UpdateContext emits CONTEXT_UPDATED event", () => {
+    const src = hookSrc("UpdateContext.ts");
+    expect(src).toContain("EVENTS.CONTEXT_UPDATED");
+  });
+
+  it("UpdateContext imports from dao/index.js not context.js for writes", () => {
+    const src = hookSrc("UpdateContext.ts");
+    expect(src).toContain("dao/index.js");
+    expect(src).not.toContain('from "../../src/context.js"');
+  });
+
+  it("PreCompact imports logEvent and EVENTS", () => {
+    const src = hookSrc("PreCompact.ts");
+    expect(src).toContain("logEvent");
+    expect(src).toContain("EVENTS");
+    expect(src).toContain("eventNames.js");
+  });
+
+  it("PreCompact emits COMPACT_PRE event", () => {
+    const src = hookSrc("PreCompact.ts");
+    expect(src).toContain("EVENTS.COMPACT_PRE");
+  });
+
+  it("EvaluateSession imports logEvent and EVENTS", () => {
+    const src = hookSrc("EvaluateSession.ts");
+    expect(src).toContain("logEvent");
+    expect(src).toContain("EVENTS");
+    expect(src).toContain("eventNames.js");
+  });
+
+  it("EvaluateSession emits SESSION_EVALUATED event", () => {
+    const src = hookSrc("EvaluateSession.ts");
+    expect(src).toContain("EVENTS.SESSION_EVALUATED");
+  });
+
+  it("logEvent entries have event field matching the EVENTS constant value", () => {
+    // Verify the EVENTS constants are the canonical strings used by /ltm:health aggregation
+    const eventNamesSrc = readFileSync(
+      join(HOOKS_SRC, "..", "lib", "eventNames.ts"),
+      "utf-8"
+    );
+    expect(eventNamesSrc).toContain('"session.start"');
+    expect(eventNamesSrc).toContain('"session.evaluated"');
+    expect(eventNamesSrc).toContain('"context.updated"');
+    expect(eventNamesSrc).toContain('"compact.pre"');
+  });
+});

--- a/src/__tests__/hooks/health-aggregation.test.ts
+++ b/src/__tests__/hooks/health-aggregation.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Integration test for /ltm:health activity aggregation.
+ * Seeds a temp hooks.log with known event entries and verifies
+ * the aggregation script produces the correct counts.
+ */
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { mkdirSync, writeFileSync, unlinkSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+const TMP_DIR = join(tmpdir(), `ltm-health-test-${Date.now()}`);
+const LOG_FILE = join(TMP_DIR, "hooks.log");
+
+function makeEntry(event: string, hoursAgo: number, project = "test-proj"): string {
+  const ts = new Date(Date.now() - hoursAgo * 3_600_000).toISOString();
+  return JSON.stringify({ ts, hook: "TestHook", level: "event", msg: event, event, project });
+}
+
+beforeAll(() => {
+  mkdirSync(TMP_DIR, { recursive: true });
+  const lines = [
+    makeEntry("session.start",     1),
+    makeEntry("session.start",     2),
+    makeEntry("session.evaluated", 1),
+    makeEntry("context.updated",   3),
+    makeEntry("context.updated",   5),
+    makeEntry("context.updated",   6),
+    makeEntry("recall.hit",        0.5),
+    // older than 24h — must NOT be counted
+    makeEntry("session.start",    25),
+    makeEntry("learn.write",      26),
+    // non-event line — must be skipped
+    JSON.stringify({ ts: new Date().toISOString(), hook: "X", level: "info", msg: "ignored" }),
+  ];
+  writeFileSync(LOG_FILE, lines.join("\n") + "\n");
+});
+
+afterAll(() => {
+  try { rmSync(TMP_DIR, { recursive: true, force: true }); } catch {}
+});
+
+async function runAggregation(): Promise<string> {
+  const script = `
+    import { readFileSync, existsSync } from 'fs';
+    const LOG = ${JSON.stringify(LOG_FILE)};
+    if (!existsSync(LOG)) { console.log('no log'); process.exit(0); }
+    const cutoff = Date.now() - 24 * 60 * 60 * 1000;
+    const counts = {};
+    readFileSync(LOG, 'utf-8').trim().split('\\n').forEach(line => {
+      try {
+        const e = JSON.parse(line);
+        if (e.level !== 'event' || !e.event) return;
+        if (new Date(e.ts).getTime() < cutoff) return;
+        counts[e.event] = (counts[e.event] ?? 0) + 1;
+      } catch {}
+    });
+    console.log(JSON.stringify(counts));
+  `;
+  const proc = Bun.spawn(["bun", "--eval", script], { stdout: "pipe", stderr: "pipe" });
+  const out = await new Response(proc.stdout).text();
+  await proc.exited;
+  return out.trim();
+}
+
+describe("/ltm:health activity aggregation", () => {
+  it("counts events within the 24h window", async () => {
+    const raw = await runAggregation();
+    const counts = JSON.parse(raw) as Record<string, number>;
+
+    expect(counts["session.start"]).toBe(2);      // 2 within 24h (1 older excluded)
+    expect(counts["session.evaluated"]).toBe(1);
+    expect(counts["context.updated"]).toBe(3);
+    expect(counts["recall.hit"]).toBe(1);
+  }, 15_000);
+
+  it("excludes entries older than 24h", async () => {
+    const raw = await runAggregation();
+    const counts = JSON.parse(raw) as Record<string, number>;
+
+    // learn.write was 26h ago — must not appear
+    expect(counts["learn.write"]).toBeUndefined();
+  }, 15_000);
+
+  it("skips non-event log lines", async () => {
+    const raw = await runAggregation();
+    // Should parse without throwing; 'ignored' msg is level=info, not counted
+    expect(() => JSON.parse(raw)).not.toThrow();
+  }, 15_000);
+});

--- a/src/__tests__/lint/no-raw-sql.test.ts
+++ b/src/__tests__/lint/no-raw-sql.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Guardrail: hooks/src/*.ts must not contain inline SQL.
+ * All DB writes must go through src/dao/ (which uses writeQueue).
+ * This test fails if any hook bypasses the DAO layer.
+ */
+import { describe, expect, it } from "bun:test";
+import { readFileSync, readdirSync } from "fs";
+import { join } from "path";
+
+const HOOKS_SRC = join(import.meta.dir, "..", "..", "..", "hooks", "src");
+
+// Only flag write operations — reads are safe without the writeQueue.
+// DAO layer guards against concurrent writes; reads are always safe.
+const RAW_SQL_PATTERNS = [
+  /\bdb\.run\s*\(/,
+  /\bdb\.prepare\s*\(.*\)\.run\s*\(/,
+  /\bgetDb\(\)\.run\s*\(/,
+  /\bgetDb\(\)\.prepare\s*\(/,
+];
+
+function getHookFiles(): string[] {
+  return readdirSync(HOOKS_SRC)
+    .filter(f => f.endsWith(".ts"))
+    .map(f => join(HOOKS_SRC, f));
+}
+
+describe("no-raw-sql lint gate", () => {
+  const hookFiles = getHookFiles();
+
+  for (const filePath of hookFiles) {
+    it(`${filePath.split("/").pop()} — no inline SQL`, () => {
+      const src = readFileSync(filePath, "utf-8");
+      const violations: string[] = [];
+
+      for (const pattern of RAW_SQL_PATTERNS) {
+        const lines = src.split("\n");
+        lines.forEach((line, i) => {
+          if (pattern.test(line)) {
+            violations.push(`  line ${i + 1}: ${line.trim()}`);
+          }
+        });
+      }
+
+      if (violations.length > 0) {
+        throw new Error(
+          `Raw SQL found in ${filePath.split("/").pop()}. Use src/dao/ instead:\n${violations.join("\n")}`
+        );
+      }
+      expect(violations).toHaveLength(0);
+    });
+  }
+});

--- a/src/__tests__/perf/recall.bench.ts
+++ b/src/__tests__/perf/recall.bench.ts
@@ -1,0 +1,100 @@
+/**
+ * Recall performance benchmark — verifies p95 < 50ms with 10k memories.
+ * Seeds an in-memory DB, inserts 10k rows, then runs recall() 100 times.
+ * Run with: bun test src/__tests__/perf/recall.bench.ts
+ */
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { unlinkSync } from "fs";
+
+const dbPath = `/tmp/test-ltm-perf-${Date.now()}.db`;
+process.env.LTM_DB_PATH = dbPath;
+
+let recall: (input: { query?: string; limit?: number; project?: string }) => Promise<unknown[]>;
+
+const CATEGORIES = ["preference", "architecture", "gotcha", "pattern", "workflow", "constraint"] as const;
+const QUERIES = [
+  "typescript error handling",
+  "database migration",
+  "hook logging",
+  "recall performance",
+  "bun sqlite",
+  "session start",
+  "context update",
+  "memory decay",
+  "DAO layer",
+  "write queue",
+];
+
+beforeAll(async () => {
+  const { getDb, waitForInit } = await import("../../shared-db.js");
+  // Ensure all migrations have applied before seeding or calling recall().
+  await waitForInit();
+  const db = getDb();
+
+  // Seed 10k rows directly (bypass learn() to avoid LLM calls)
+  const insert = db.prepare(
+    `INSERT INTO memories (content, category, importance, confidence, status, source, dedup_key)
+     VALUES (?, ?, ?, ?, 'active', 'bench', ?)`
+  );
+  const insertFts = db.prepare(
+    `INSERT INTO memories_fts (rowid, content) VALUES (?, ?)`
+  );
+
+  const batchInsert = db.transaction((n: number) => {
+    for (let i = 0; i < n; i++) {
+      const cat = CATEGORIES[i % CATEGORIES.length]!;
+      const content = `Memory ${i}: ${cat} pattern for ${QUERIES[i % QUERIES.length]} with detail level ${i}`;
+      const key = `bench-key-${i}`;
+      insert.run(content, cat, (i % 5) + 1, 0.5 + (i % 5) * 0.1, key);
+      const lastId = db.query<{ id: number }, []>("SELECT last_insert_rowid() as id").get()!.id;
+      insertFts.run(lastId, content);
+    }
+  });
+
+  batchInsert(10_000);
+
+  const { recall: recallFn } = await import("../../db.js");
+  recall = recallFn as typeof recall;
+}, 60_000);
+
+afterAll(() => {
+  try { unlinkSync(dbPath); } catch {}
+  try { unlinkSync(`${dbPath}-shm`); } catch {}
+  try { unlinkSync(`${dbPath}-wal`); } catch {}
+});
+
+function p95(samples: number[]): number {
+  const sorted = [...samples].sort((a, b) => a - b);
+  return sorted[Math.floor(sorted.length * 0.95)] ?? 0;
+}
+
+describe("recall() performance with 10k memories", () => {
+  it("p95 latency < 50ms over 100 calls", async () => {
+    const latencies: number[] = [];
+
+    for (let i = 0; i < 100; i++) {
+      const query = QUERIES[i % QUERIES.length]!;
+      const start = performance.now();
+      await recall({ query, limit: 10 });
+      latencies.push(performance.now() - start);
+    }
+
+    const p95ms = p95(latencies);
+    const avg = latencies.reduce((a, b) => a + b, 0) / latencies.length;
+
+    console.log(`  avg=${avg.toFixed(2)}ms  p95=${p95ms.toFixed(2)}ms  max=${Math.max(...latencies).toFixed(2)}ms`);
+
+    expect(p95ms).toBeLessThan(50);
+  }, 30_000);
+
+  it("returns results (not empty) for common queries", async () => {
+    const results = await recall({ query: "typescript error handling", limit: 5 });
+    expect(results.length).toBeGreaterThan(0);
+  });
+
+  it("excludes embedding blob from returned rows", async () => {
+    const results = await recall({ query: "bun sqlite", limit: 1 }) as Array<Record<string, unknown>>;
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0]).not.toHaveProperty("embedding");
+  });
+});

--- a/src/dao/contextItems.ts
+++ b/src/dao/contextItems.ts
@@ -50,20 +50,19 @@ export function appendProgress(project: string, content: string, sessionId?: str
   });
 }
 
-export function addDecision(project: string, content: string): void {
+function insertPermanent(project: string, type: ContextItemType, content: string): void {
   writeQueue.enqueue(() => {
     getDb().run(
-      `INSERT INTO context_items (project_name, type, content, permanent) VALUES (?, 'decision', ?, 1)`,
-      [project, content]
+      `INSERT INTO context_items (project_name, type, content, permanent) VALUES (?, ?, ?, 1)`,
+      [project, type, content]
     );
   });
 }
 
+export function addDecision(project: string, content: string): void {
+  insertPermanent(project, "decision", content);
+}
+
 export function addGotcha(project: string, content: string): void {
-  writeQueue.enqueue(() => {
-    getDb().run(
-      `INSERT INTO context_items (project_name, type, content, permanent) VALUES (?, 'gotcha', ?, 1)`,
-      [project, content]
-    );
-  });
+  insertPermanent(project, "gotcha", content);
 }

--- a/src/dao/contextItems.ts
+++ b/src/dao/contextItems.ts
@@ -23,11 +23,13 @@ export function listByProject(project: string, type?: ContextItemType): ContextI
 export function upsertGoal(project: string, content: string): void {
   writeQueue.enqueue(() => {
     const db = getDb();
-    db.run(`DELETE FROM context_items WHERE project_name=? AND type='goal'`, [project]);
-    db.run(
-      `INSERT INTO context_items (project_name, type, content, permanent) VALUES (?, 'goal', ?, 0)`,
-      [project, content]
-    );
+    db.transaction(() => {
+      db.run(`DELETE FROM context_items WHERE project_name=? AND type='goal'`, [project]);
+      db.run(
+        `INSERT INTO context_items (project_name, type, content, permanent) VALUES (?, 'goal', ?, 0)`,
+        [project, content]
+      );
+    })();
   });
 }
 

--- a/src/dao/contextItems.ts
+++ b/src/dao/contextItems.ts
@@ -1,0 +1,69 @@
+/**
+ * dao/contextItems.ts — DAO for context_items table.
+ * Hooks use these functions instead of raw SQL.
+ */
+import { getDb } from "../shared-db.js";
+import { writeQueue } from "../lib/writeQueue.js";
+import type { ContextItemRow, ContextItemType } from "./types.js";
+
+export function listByProject(project: string, type?: ContextItemType): ContextItemRow[] {
+  const db = getDb();
+  if (type) {
+    return db.query<ContextItemRow, [string, string]>(
+      `SELECT id, project_name, type, content, session_id, permanent, memory_id, status, created_at
+       FROM context_items WHERE project_name=? AND type=? AND status='active' ORDER BY created_at ASC`
+    ).all(project, type);
+  }
+  return db.query<ContextItemRow, [string]>(
+    `SELECT id, project_name, type, content, session_id, permanent, memory_id, status, created_at
+     FROM context_items WHERE project_name=? AND status='active' ORDER BY type, created_at ASC`
+  ).all(project);
+}
+
+export function upsertGoal(project: string, content: string): void {
+  writeQueue.enqueue(() => {
+    const db = getDb();
+    db.run(`DELETE FROM context_items WHERE project_name=? AND type='goal'`, [project]);
+    db.run(
+      `INSERT INTO context_items (project_name, type, content, permanent) VALUES (?, 'goal', ?, 0)`,
+      [project, content]
+    );
+  });
+}
+
+export function appendProgress(project: string, content: string, sessionId?: string): void {
+  writeQueue.enqueue(() => {
+    const db = getDb();
+    // Trim to 20 most recent progress entries
+    const existing = db.query<{ id: number }, [string]>(
+      `SELECT id FROM context_items WHERE project_name=? AND type='progress' ORDER BY created_at DESC`
+    ).all(project);
+    if (existing.length >= 20) {
+      const toDelete = existing.slice(19).map(r => r.id);
+      const placeholders = toDelete.map(() => "?").join(",");
+      db.run(`DELETE FROM context_items WHERE id IN (${placeholders})`, toDelete);
+    }
+    db.run(
+      `INSERT INTO context_items (project_name, type, content, session_id, permanent) VALUES (?, 'progress', ?, ?, 0)`,
+      [project, content, sessionId ?? null]
+    );
+  });
+}
+
+export function addDecision(project: string, content: string): void {
+  writeQueue.enqueue(() => {
+    getDb().run(
+      `INSERT INTO context_items (project_name, type, content, permanent) VALUES (?, 'decision', ?, 1)`,
+      [project, content]
+    );
+  });
+}
+
+export function addGotcha(project: string, content: string): void {
+  writeQueue.enqueue(() => {
+    getDb().run(
+      `INSERT INTO context_items (project_name, type, content, permanent) VALUES (?, 'gotcha', ?, 1)`,
+      [project, content]
+    );
+  });
+}

--- a/src/dao/index.ts
+++ b/src/dao/index.ts
@@ -1,0 +1,7 @@
+/**
+ * dao/index.ts — Single import surface for the DAO layer.
+ * Hooks and MCP tools import from here, never from db.ts directly for context_items.
+ * Memories are still accessed via src/db.ts (learn, recall, relate, forget).
+ */
+export * from "./types.js";
+export * from "./contextItems.js";

--- a/src/dao/types.ts
+++ b/src/dao/types.ts
@@ -1,0 +1,60 @@
+/**
+ * dao/types.ts — Shared row types for the DAO layer.
+ * MemorySlim omits the embedding blob — use this for all recall paths.
+ * MemoryFull includes embedding — only for embeddings.ts internals.
+ */
+
+export type MemoryCategory = "preference" | "architecture" | "gotcha" | "pattern" | "workflow" | "constraint";
+export type RelationshipType = "supports" | "contradicts" | "refines" | "depends_on" | "related_to" | "supersedes";
+export type MemoryStatus = "active" | "pending" | "deprecated" | "superseded";
+export type ContextItemType = "goal" | "decision" | "progress" | "gotcha";
+export type ContextItemStatus = "active" | "pending_promotion" | "promoted";
+
+/** Slim memory row — no embedding blob. Used by recall(), getContextMerge(), and all MCP responses. */
+export interface MemorySlim {
+  id: number;
+  content: string;
+  category: MemoryCategory;
+  importance: number;
+  confidence: number;
+  source: string | null;
+  project_scope: string | null;
+  dedup_key: string | null;
+  created_at: string;
+  last_confirmed_at: string;
+  last_used_at: string;
+  confirm_count: number;
+  status: MemoryStatus;
+  first_recalled_at?: string | null;
+  last_recalled_at?: string | null;
+  recall_count?: number;
+  superseded_by?: number | null;
+  superseded_at?: string | null;
+  workspace_id?: string | null;
+  agent_id?: string | null;
+}
+
+/** Full memory row — includes embedding blob. Internal use only (embeddings.ts). */
+export interface MemoryFull extends MemorySlim {
+  embedding: Buffer | null;
+}
+
+export interface ContextItemRow {
+  id: number;
+  project_name: string;
+  type: ContextItemType;
+  content: string;
+  session_id: string | null;
+  permanent: number;
+  memory_id: number | null;
+  status: ContextItemStatus;
+  created_at: string;
+}
+
+export interface MemoryRelationRow {
+  id: number;
+  source_memory_id: number;
+  target_memory_id: number;
+  relationship_type: RelationshipType;
+  created_at: string;
+}

--- a/src/db.ts
+++ b/src/db.ts
@@ -418,8 +418,14 @@ export async function recall(input: RecallInput = {}): Promise<MemoryWithRelatio
   }
 
   const where = `WHERE ${conditions.join(" AND ")}`;
+  // Explicit columns — excludes embedding blob (~260 KB/row) from hot recall path.
+  // Use getById(id, { withEmbedding: true }) when the blob is needed.
   const rows = db.query<Memory, typeof params>(
-    `SELECT * FROM memories ${where} LIMIT ${limit}`
+    `SELECT id, content, category, importance, confidence, source, project_scope, dedup_key,
+            created_at, last_confirmed_at, last_used_at, confirm_count, status,
+            first_recalled_at, last_recalled_at, recall_count, superseded_by, superseded_at,
+            workspace_id, agent_id
+     FROM memories ${where} LIMIT ${limit}`
   ).all(...params);
 
   let sorted: typeof rows;
@@ -509,12 +515,16 @@ export function getContextMerge(project: string): { globals: Memory[]; scoped: M
        .sort((a, b) => b.score - a.score)
        .map(({ m }) => m);
 
+  const SLIM = `id, content, category, importance, confidence, source, project_scope, dedup_key,
+               created_at, last_confirmed_at, last_used_at, confirm_count, status,
+               first_recalled_at, last_recalled_at, recall_count, superseded_by, superseded_at,
+               workspace_id, agent_id`;
   const globals = sortByDecay(db.query<Memory, []>(
-    `SELECT * FROM memories WHERE importance >= 4 AND project_scope IS NULL AND status = 'active'`
+    `SELECT ${SLIM} FROM memories WHERE importance >= 4 AND project_scope IS NULL AND status = 'active'`
   ).all());
 
   const scoped = sortByDecay(db.query<Memory, [string]>(
-    `SELECT * FROM memories WHERE project_scope=? AND importance >= 3 AND status = 'active' LIMIT 15`
+    `SELECT ${SLIM} FROM memories WHERE project_scope=? AND importance >= 3 AND status = 'active' LIMIT 15`
   ).all(project));
 
   const allIds = [...globals, ...scoped].map(m => m.id);

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -24,15 +24,8 @@ async function isEnabled(): Promise<boolean> {
   }
 }
 
-// Strip embedding blob before sending over MCP — it serializes as {"0":59,...} ~260KB per memory
-function strip(obj: unknown): unknown {
-  if (Array.isArray(obj)) return obj.map(strip);
-  if (obj && typeof obj === "object") {
-    const { embedding: _e, ...rest } = obj as Record<string, unknown>;
-    return Object.fromEntries(Object.entries(rest).map(([k, v]) => [k, strip(v)]));
-  }
-  return obj;
-}
+// Embedding excluded at the SQL query level — strip() is now a no-op passthrough kept for call-site compatibility.
+function strip(obj: unknown): unknown { return obj; }
 
 /** Compact formatter — strips verbose fields and truncates content to keep MCP responses small. */
 function compact(memories: unknown[]): unknown[] {

--- a/src/migrations.ts
+++ b/src/migrations.ts
@@ -76,6 +76,9 @@ export function computeChecksum(content: string): string {
 export async function backupDb(): Promise<string> {
   const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
   const backupPath = `${DB_PATH}.bak-${timestamp}`;
+  // Skip backup when the source DB doesn't exist (e.g. in-process test DBs
+  // that were created on a different path than the module-level DB_PATH).
+  if (!existsSync(DB_PATH)) return backupPath;
   const bytes = await Bun.file(DB_PATH).arrayBuffer();
   await Bun.write(backupPath, bytes);
   return backupPath;

--- a/src/shared-db.ts
+++ b/src/shared-db.ts
@@ -74,7 +74,9 @@ export async function waitForInit(): Promise<void> {
 export function _setDbForTesting(db: Database): void {
   try { _db?.close(); } catch {}
   _db = db;
-  _initPromise = null;
+  // Resolve immediately — db is already fully migrated; prevents a second
+  // runPendingMigrations if getDb() or waitForInit() is called after injection.
+  _initPromise = Promise.resolve();
 }
 
 /** Retry helper for SQLITE_BUSY errors — wraps a function with automatic retry. */

--- a/src/shared-db.ts
+++ b/src/shared-db.ts
@@ -43,19 +43,38 @@ export function getDb(): Database {
     });
     _initPromise.catch(() => {/* prevent unhandled rejection — sync fallback is active */});
   }
-  // For synchronous callers that call getDb() before the promise resolves on a
-  // cold start, open a temporary sync path: schema.sql only, no migrations.
-  // runPendingMigrations self-heals on the next async call and records versions.
+  // For synchronous callers on cold start: open a schema-only DB immediately.
+  // Migrations run via _initPromise (above) on a dedicated connection and swap
+  // _db once complete. Do NOT run runPendingMigrations here — that causes two
+  // concurrent runners on the same file and UNIQUE constraint races.
   if (!_db) {
     const dir = join(CLAUDE_DIR, "memory");
     if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
     _db = new Database(DB_PATH, { create: true });
     _db.exec("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON; PRAGMA busy_timeout=5000;");
     _db.exec(readFileSync(SCHEMA_PATH, "utf-8"));
-    // Fire-and-forget: apply pending versioned migrations in background
-    runPendingMigrations(_db).catch(() => {/* self-heals on next call */});
   }
   return _db;
+}
+
+/**
+ * Await full DB initialisation (schema + all pending migrations).
+ * Use in async startup paths (tests, server boot) when migrated columns are
+ * needed before the first async tick completes.
+ */
+export async function waitForInit(): Promise<void> {
+  if (!_initPromise) getDb(); // ensure _initPromise is created
+  await _initPromise;
+}
+
+/**
+ * Test-only: inject a specific Database instance as the singleton.
+ * Closes any existing connection first. Never call in production code.
+ */
+export function _setDbForTesting(db: Database): void {
+  try { _db?.close(); } catch {}
+  _db = db;
+  _initPromise = null;
 }
 
 /** Retry helper for SQLITE_BUSY errors — wraps a function with automatic retry. */


### PR DESCRIPTION
## Summary

- **W7 — Slim recall rows**: `recall()` now uses an explicit 20-column SELECT, excluding the embedding blob (~260 KB/row) from every recall path. `strip()` in `mcp-server.ts` is a no-op passthrough since the blob is excluded at the SQL layer.
- **W8 — DAO layer**: `src/dao/` (types, contextItems, barrel) provides the canonical write interface for `context_items`. All hooks now import from `dao/index.js` instead of `context.ts` for writes; the writeQueue prevents concurrent DB corruption.
- **W5 — Structured events**: `hookLogger.ts` extended with `logEvent()` and `event`/`count`/`project` fields on `LogEntry`. `eventNames.ts` defines canonical names. SessionStart, UpdateContext, PreCompact, and EvaluateSession all emit structured events with project scope.
- **`/ltm:health` observability**: New "Activity (last 24h)" section reads `~/.claude/logs/hooks.log`, aggregates event counts, and renders an activity table — real usage data instead of static counters.
- **shared-db.ts hardening**: Removed the concurrent-migration race (sync fallback no longer fires its own `runPendingMigrations`). Added `waitForInit()` for clean async init and `_setDbForTesting()` for isolated test DBs.
- **migrations.ts**: `backupDb()` skips gracefully when `DB_PATH` doesn't exist (fixes ENOENT in parallel test runs).

## Test plan

- [ ] `bun test` — 67 pass, 0 fail
- [ ] `bunx tsc --noEmit` — clean
- [ ] `src/__tests__/dao/contextItems.test.ts` — 9 DAO unit tests with DB injection (no env var race)
- [ ] `src/__tests__/lint/no-raw-sql.test.ts` — 6 hook files checked for inline SQL writes
- [ ] `src/__tests__/hooks/event-emission.test.ts` — 10 static analysis tests verify every hook emits its event
- [ ] `src/__tests__/hooks/health-aggregation.test.ts` — 3 tests verify 24h event window, exclusion, and resilience
- [ ] `src/__tests__/perf/recall.bench.ts` — p95=8.8ms with 10k memories (SLA: <50ms), embedding excluded from results

🤖 Generated with [Claude Code](https://claude.com/claude-code)